### PR TITLE
updated completeAuthorizationRequest and query_string_utils parse to …

### DIFF
--- a/src/query_string_utils.ts
+++ b/src/query_string_utils.ts
@@ -20,13 +20,13 @@ import {LocationLike, StringMap} from './types';
  */
 export interface QueryStringUtils {
   stringify(input: StringMap): string;
-  parse(query: LocationLike, useHash?: boolean): StringMap;
+  parse(query: LocationLike): StringMap;
   parseQueryString(query: string): StringMap;
 }
 
 export class BasicQueryStringUtils implements QueryStringUtils {
-  parse(input: LocationLike, useHash?: boolean) {
-    if (useHash) {
+  parse(input: LocationLike) {
+    if (input.hash) {
       return this.parseQueryString(input.hash);
     } else {
       return this.parseQueryString(input.search);

--- a/src/redirect_based_handler.ts
+++ b/src/redirect_based_handler.ts
@@ -97,7 +97,7 @@ export class RedirectRequestHandler extends AuthorizationRequestHandler {
             .then(request => {
               // check redirect_uri and state
               let currentUri = `${this.locationLike.origin}${this.locationLike.pathname}`;
-              let queryParams = this.utils.parse(this.locationLike, true /* use hash */);
+              let queryParams = this.utils.parse(this.locationLike);
               let state: string|undefined = queryParams['state'];
               let code: string|undefined = queryParams['code'];
               let error: string|undefined = queryParams['error'];


### PR DESCRIPTION
fixes https://github.com/openid/AppAuth-JS/issues/114

This function is only used in one location. Wouldn't it make more sense to update the function to be able to handle both routing types? Instead of having the user overload your internal function in the application code? 

