### PR TITLE
xhr: set the method explicitly

### DIFF
--- a/src/authorization_service_configuration.ts
+++ b/src/authorization_service_configuration.ts
@@ -75,7 +75,7 @@ export class AuthorizationServiceConfiguration {
     const requestorToUse = requestor || new JQueryRequestor();
 
     return requestorToUse
-        .xhr<AuthorizationServiceConfigurationJson>({url: fullUrl, dataType: 'json'})
+        .xhr<AuthorizationServiceConfigurationJson>({url: fullUrl, dataType: 'json', method: 'GET'})
         .then(json => new AuthorizationServiceConfiguration(json));
   }
 }


### PR DESCRIPTION
As stated in https://api.jquery.com/jquery.ajax/#jQuery-ajax-settings the default value for `method` is `GET`. The same happens for Fetch API, so everything works fine in current browsers if `method` is left unset in both implementations.

There is a problem with older versions of Chrome, though. Chrome 53 (and surrounding versions) didn't honor this default value of Fetch API, and if you leave it unset it provokes an error in those versions.

@tikurahul How'd you feel if we set this `method` value to `GET` explicitly? It'd make no difference for current browsers, but we'd support older Chrome versions 😊.