### PR TITLE
Added convert value expiresIn to number.

### DIFF
--- a/src/token_response.ts
+++ b/src/token_response.ts
@@ -96,7 +96,7 @@ export class TokenResponse {
   isValid(buffer: number = AUTH_EXPIRY_BUFFER): boolean {
     if (this.expiresIn) {
       let now = nowInSeconds();
-      return now < this.issuedAt + this.expiresIn + buffer;
+      return now < Number(this.issuedAt) + Number(this.expiresIn) + Number(buffer);
     } else {
       return true;
     }


### PR DESCRIPTION
In Ionic framework 4 (with Angular 8 and Azure AD as login provider) without convert Number(this.expiresIn) **isValid()** function often return false (e.g. when expiresIn has value 3600 and buffer has value -600). It occurs only on mobile device (run on Samsung A40, Android 9.0, Chrome 78) with authorization code flow - then Azure AD return unfortunately _expiresIn_ value as **string**. While testing in web browser on computer (Windows 10, Chrome 78) then is OK, in this case Azure AD return _expiresIn_ value as **number**.