### PR TITLE
Updated parse to accept both search and hash

### DIFF
--- a/src/redirect_based_handler.ts
+++ b/src/redirect_based_handler.ts
@@ -97,7 +97,8 @@ export class RedirectRequestHandler extends AuthorizationRequestHandler {
             .then(request => {
               // check redirect_uri and state
               let currentUri = `${this.locationLike.origin}${this.locationLike.pathname}`;
-              let queryParams = this.utils.parse(this.locationLike, true /* use hash */);
+              const useHash = (this.locationLike.hash !== '')
+              let queryParams = this.utils.parse(this.locationLike, useHash);
               let state: string|undefined = queryParams['state'];
               let code: string|undefined = queryParams['code'];
               let error: string|undefined = queryParams['error'];


### PR DESCRIPTION
I noticed that the hash setting was hard coded. The google openId doesn't have an option for using hash over search params.  Since the utils.parse has the option for using hash or not, I added the check for the locationLike.hash not to be empty.