### PR TITLE
Client secret option

### DIFF
--- a/built/token_request.d.ts
+++ b/built/token_request.d.ts
@@ -10,6 +10,7 @@ export interface TokenRequestJson {
     refresh_token?: string;
     redirect_uri: string;
     client_id: string;
+    client_secret?: string;
     extras?: StringMap;
 }
 /**
@@ -19,6 +20,7 @@ export interface TokenRequestJson {
  */
 export declare class TokenRequest {
     clientId: string;
+    clientSecret: string | undefined;
     redirectUri: string;
     grantType: string;
     code: string | undefined;

--- a/built/token_request.js
+++ b/built/token_request.js
@@ -23,6 +23,7 @@ exports.GRANT_TYPE_REFRESH_TOKEN = 'refresh_token';
 var TokenRequest = /** @class */ (function () {
     function TokenRequest(request) {
         this.clientId = request.client_id;
+        this.clientSecret = request.client_secret;
         this.redirectUri = request.redirect_uri;
         this.grantType = request.grant_type;
         this.code = request.code;
@@ -39,6 +40,7 @@ var TokenRequest = /** @class */ (function () {
             refresh_token: this.refreshToken,
             redirect_uri: this.redirectUri,
             client_id: this.clientId,
+            client_secret: this.clientSecret,
             extras: this.extras
         };
     };
@@ -46,6 +48,7 @@ var TokenRequest = /** @class */ (function () {
         var map = {
             grant_type: this.grantType,
             client_id: this.clientId,
+            client_secret: this.clientSecret,
             redirect_uri: this.redirectUri
         };
         if (this.code) {

--- a/built/token_request_test.js
+++ b/built/token_request_test.js
@@ -16,11 +16,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var token_request_1 = require("./token_request");
 describe('Token Request tests', function () {
     var clientId = 'client_id';
+    var clientSecret = 'client_secret';
     var redirectUri = 'http://my/redirect_uri';
     var code = 'some_code';
     var extras = { 'key': 'value' };
     var request = new token_request_1.TokenRequest({
         client_id: clientId,
+        client_secret: clientSecret,
         redirect_uri: redirectUri,
         grant_type: token_request_1.GRANT_TYPE_AUTHORIZATION_CODE,
         code: code,
@@ -30,6 +32,7 @@ describe('Token Request tests', function () {
     it('Basic Token Request Tests', function () {
         expect(request).not.toBeNull();
         expect(request.clientId).toBe(clientId);
+        expect(newRequest.clientSecret).toBe(clientSecret);
         expect(request.redirectUri).toBe(redirectUri);
         expect(request.code).toBe(code);
         expect(request.grantType).toBe(token_request_1.GRANT_TYPE_AUTHORIZATION_CODE);
@@ -43,6 +46,7 @@ describe('Token Request tests', function () {
         var newRequest = new token_request_1.TokenRequest(json);
         expect(newRequest).not.toBeNull();
         expect(newRequest.clientId).toBe(clientId);
+        expect(newRequest.clientSecret).toBe(clientSecret);
         expect(newRequest.redirectUri).toBe(redirectUri);
         expect(newRequest.code).toBe(code);
         expect(newRequest.grantType).toBe(token_request_1.GRANT_TYPE_AUTHORIZATION_CODE);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+---
+version: "3"
+services:
+  development: &base
+    image: node:12.16.1 # match what is in .nvmrc
+    volumes:
+      - ./:/app
+    working_dir: /app
+    command: ["npm","run-script","docker-compose"]
+      # ["tail", "-f", "/dev/null"]
+
+  test:
+    <<: *base
+    image: circleci/node:12.16-browsers
+    command: ["npm", "test"]

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "pregzipSize": "npm run-script --silent minify",
     "gzipSize": "gzip -c built/app/bundle_minified.js | wc -c",
     "prewatch": "npm run-script --silent format",
-    "watch": "node_modules/.bin/tsc --watch &"
+    "watch": "node_modules/.bin/tsc --watch &",
+    "docker-compose": "npm install && npm run-script compile && node_modules/.bin/tsc --watch"
   },
   "keywords": [
     "OAuth",


### PR DESCRIPTION
This aims to solve https://github.com/openid/AppAuth-JS/issues/46 by adding the option to configure client_secret.

Some IDPs require this such as Googles /token endpoint.

see also: 
- https://github.com/Netflix/dispatch/issues/492
- https://developers.google.com/identity/protocols/oauth2/native-app#exchange-authorization-code