### PR TITLE
Explicitly request "response_mode=fragment" in authorization requests

### DIFF
--- a/src/authorization_request_handler.ts
+++ b/src/authorization_request_handler.ts
@@ -90,6 +90,9 @@ export abstract class AuthorizationRequestHandler {
       'redirect_uri': request.redirectUri,
       'client_id': request.clientId,
       'response_type': request.responseType,
+      // Only 'fragment' response_mode is supported, as query strings tend to up in Referer headers.
+      // See: https://github.com/openid/AppAuth-JS/issues/137
+      'response_mode': 'fragment',
       'state': request.state,
       'scope': request.scope
     };


### PR DESCRIPTION
This parameter is specified by https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html

Since this library deviates from the OAuth specification by unconditionally expecting a `fragment` response, this expectation needs to be communicated to the authorization server, to give it a chance to respond appropriately. Otherwise, servers must hardcode the use of a `fragment` response, which may prevent interoperability with other OAuth clients.

---

This should help the problems reported in #137 and #151, to the extent that servers also start supporting the `response_mode` option.