### PR TITLE
Use cross-OS way to delete build output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3133,6 +3133,12 @@
         "picomatch": "^2.2.1"
       }
     },
+    "recursive-fs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/recursive-fs/-/recursive-fs-2.1.0.tgz",
+      "integrity": "sha512-oed3YruYsD52Mi16s/07eYblQOLi5dTtxpIJNdfCEJ7S5v8dDgVcycar0pRWf4IBuPMIkoctC8RTqGJzIKMNAQ==",
+      "dev": true
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "compile": "node_modules/.bin/tsc",
     "prepare": "npm run-script --silent build-app",
     "format": "node_modules/.bin/clang-format -i -style=file --glob=src/**.ts",
-    "clean": "rm -rf built",
+    "clean": "node -e \"require('recursive-fs').rmdirr(require('path').resolve('built'), ()=>{})\"",
     "pretest": "npm run-script --silent compile",
     "test": "node_modules/.bin/karma start karma.conf --browsers=Chrome --single-run=false --debug",
     "pregzipSize": "npm run-script --silent minify",
@@ -58,6 +58,7 @@
     "karma-browserify": "^7.0.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-jasmine": "^4.0.1",
+    "recursive-fs": "^2.1.0",
     "typescript": "^4.0.2",
     "watchify": "^3.11.1"
   },


### PR DESCRIPTION
Fixes #175

Saw #175 come by in my feed. Have successfully solved this with the `rimraf` npm package which is one of the suggestions in [the top Stack Overflow post on the subject](https://stackoverflow.com/questions/48120889/cross-platform-rm-command), but I personally agree with [the lower voted answer](https://stackoverflow.com/a/54361341/419956) that for such a simple task using a package with less dependencies seems preferable.

I've tested this on my Windows 10 machine, not yet on any Linux VM (nor did I see any CI or GitHub actions in this repo to verify it?). Will first see what the maintainers think of this approach.

If you don't like this approach: no harm done! Your call.

(I realize the title of #175 is "Powershell support", but I took it to be in general about cross-OS and cross-shell support. It should also work with `cmd`, right?)